### PR TITLE
Force use of python3

### DIFF
--- a/proliferate
+++ b/proliferate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json, argparse, os, csv, time, requests, re, textwrap, sys
 from datetime import datetime


### PR DESCRIPTION
Depending on the machine, env may evaluate python as either
python2 or python3. Because the code is not compatible with 
python2 (see line 15), the shebang should specify that we want
to run python3