### PR TITLE
docs: Add instructions for jsPsych 7.0

### DIFF
--- a/docs/javascript-library.rst
+++ b/docs/javascript-library.rst
@@ -62,7 +62,16 @@ with
 
 ------
 
-If you are using `jsPsych <https://www.jspsych.org>`_ set the ``on_finish`` property in the ``init()`` call  to a function that calls ``proliferate.submit``:
+If you are using version 7 of `jsPsych <https://www.jspsych.org>`_ set the ``on_finish`` property of ``initJsPsych()`` to a function that calls ``proliferate.submit``:
+
+.. code-block:: js
+   var jsPsych = initJsPsych({
+        on_finish: function() {
+                proliferate.submit({"trials": jsPsych.data.get().values()});
+        }
+   });
+
+If you are using version 6 or earlier, set the ``on_finish`` property in the ``init()`` call  to a function that calls ``proliferate.submit``:
 
 .. code-block:: js
 


### PR DESCRIPTION
The new major version of jsPsych changes the init call and the
data access which obsoletes the proliferate docs. This commit
updates the instructions for the new version while maintaining
the old instructions for thosewho still use versions <= 6.